### PR TITLE
Replace incorrect use of the term "library"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # DVRAV777Interface
-A Arduino library for interfacing with the front panel of a AV777 DVR for case mods, etc.
+A Arduino sketch for interfacing with the front panel of a AV777 DVR for case mods, etc.


### PR DESCRIPTION
This is a sketch, not a library, so it's incorrect to call it a "library".

This error also occurs in the repository description. That can not be fixed via a pull request but it's easily done by clicking the **Edit** button to the right of the description text shown at the top of the repository's home page:
https://github.com/GeekLogan/DVRAV777Interface